### PR TITLE
Current track at store

### DIFF
--- a/js/actions/webamp.ts
+++ b/js/actions/webamp.ts
@@ -1,11 +1,15 @@
 import { Action, Dispatch } from "redux";
 import Webamp, * as WebampInstance from "webamp";
 import { AppState } from "../reducers";
-import { PLAY, SET_WEBAMP } from "../reducers/webamp";
+import { PLAY, SET_CURRENT_TRACK, SET_WEBAMP } from "../reducers/webamp";
 import { CLOSE_WEBAMP, OPEN_WEBAMP } from "../reducers/windows";
 import SpotifyMedia from "../spotifymedia";
 import { TrackFile } from "../types";
 import { formatMetaToWebampMeta } from "../utils/dataTransfer";
+
+export type SetTrackCallback = (
+  trackInfo: WebampInstance.LoadedURLTrack | null
+) => void;
 
 export function setOfflineWebamp(): any {
   return (dispatch: Dispatch<Action>, getState: () => AppState) => {
@@ -86,6 +90,26 @@ export function setConnectedWebamp(): any {
     dispatch({ type: SET_WEBAMP, payload: { webampObject } });
   };
 }
+
+export const setOnTrackChangedCallback = (callback: SetTrackCallback) => (
+  dispatch: Dispatch<Action>,
+  getState: () => AppState
+) => {
+  const {
+    webamp: { webampObject }
+  } = getState();
+  if (!webampObject) return;
+  webampObject.onTrackDidChange(callback);
+};
+
+export const setCurrentPlayedTrack = (track: WebampInstance.TrackInfo) => (
+  dispatch: Dispatch<Action>
+) => {
+  dispatch({
+    type: SET_CURRENT_TRACK,
+    payload: { track }
+  });
+};
 
 export function openWebamp() {
   return (dispatch: Dispatch<Action>, getState: () => AppState) => {

--- a/js/components/App.tsx
+++ b/js/components/App.tsx
@@ -5,6 +5,7 @@ import styled, { createGlobalStyle } from "styled-components";
 import packageJson from "../../package.json";
 import { AppState } from "../reducers";
 import Desktop from "./Desktop";
+import { MetaServices } from "./MetaServices";
 import SelectionBox from "./Reusables/SelectionBox";
 import Settings from "./Settings";
 import TaskBar from "./TaskBar";
@@ -64,6 +65,7 @@ export default () => {
           CHANGELOG - {packageJson.version}
         </a> */}
       </AbsoluteBottom>
+      <MetaServices />
     </div>
   );
 };

--- a/js/components/MetaServices/WinampHiddenMetadata.tsx
+++ b/js/components/MetaServices/WinampHiddenMetadata.tsx
@@ -1,0 +1,23 @@
+import React, { FC } from "react";
+import { TrackInfo } from "webamp";
+
+interface HiddenMetadataProps {
+  track?: TrackInfo;
+}
+
+/***
+ * Metadata used in web-scrobbler plugin.
+ * Web-scrobbler connectors use DOM elements to figure out what's playing now
+ * @see https://github.com/web-scrobbler/web-scrobbler/wiki/Connectors-development
+ */
+export const HiddenMetadata: FC<HiddenMetadataProps> = ({ track }) => (
+  <div id="winamp-meta" style={{ display: "none" }}>
+    {track && (
+      <>
+        <p id="winamp-meta-artist">{track.metaData.artist}</p>
+        <p id="winamp-meta-title">{track.metaData.title}</p>
+        <p id="winamp-meta-album">{track.metaData.album}</p>
+      </>
+    )}
+  </div>
+);

--- a/js/components/MetaServices/index.tsx
+++ b/js/components/MetaServices/index.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { useSelector } from "react-redux";
+import { AppState } from "../../reducers";
+import { HiddenMetadata } from "./WinampHiddenMetadata";
+
+export const MetaServices = () => {
+  const trackInfo = useSelector((x: AppState) => x.webamp.currentTrack);
+  return (
+    <>
+      <HiddenMetadata track={trackInfo} />
+    </>
+  );
+};

--- a/js/components/TaskBar/index.tsx
+++ b/js/components/TaskBar/index.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent } from "react";
 import { FaFolder, FaImage } from "react-icons/fa";
 import { useDispatch, useSelector } from "react-redux";
 import styled from "styled-components";
+import { TrackInfo } from "webamp";
 import { setOnTop, toggleMinimize } from "../../actions/windows";
 import { AppState } from "../../reducers";
 import { SingleExplorerState } from "../../reducers/explorer";
@@ -18,6 +19,7 @@ const TaskBar: FunctionComponent = props => {
   );
   const images = useSelector(selectImages);
   const windows = useSelector((state: AppState) => state.windows.windows);
+  const trackInfo = useSelector((x: AppState) => x.webamp.currentTrack);
 
   const windowOnTop = windows.find(
     w => w.position === findHighestPosition(windows)
@@ -60,7 +62,7 @@ const TaskBar: FunctionComponent = props => {
     );
   };
 
-  const renderWinamp = (w: Window) => {
+  const renderWinamp = (w: Window, t: TrackInfo) => {
     const otherWindowOnTop = windows
       .filter(win => win.id !== w.id)
       .find(
@@ -68,6 +70,9 @@ const TaskBar: FunctionComponent = props => {
           win.position ===
           findHighestPosition(windows.filter(win => win.id !== w.id))
       );
+    const titleString = t
+      ? `${t.metaData.artist} - ${t.metaData.title}`
+      : "Winamp";
     return (
       <Item
         minimized={w.minimized}
@@ -93,7 +98,7 @@ const TaskBar: FunctionComponent = props => {
             marginRight: 4
           }}
         />
-        <Text>{"Winamp"}</Text>
+        <Text id="winamp-title">{titleString}</Text>
       </Item>
     );
   };
@@ -146,13 +151,12 @@ const TaskBar: FunctionComponent = props => {
           return renderExplorer(window);
         }
         if (window.type === WINDOW_TYPE.Webamp) {
-          return renderWinamp(window);
+          return renderWinamp(window, trackInfo);
         }
         if (window.type === WINDOW_TYPE.Image) {
           return renderImage(window);
         }
       })}
-      F
     </Container>
   );
 };

--- a/js/components/Webamp/index.tsx
+++ b/js/components/Webamp/index.tsx
@@ -5,7 +5,9 @@ import {
   openWebamp,
   removeWebamp,
   setConnectedWebamp,
-  setOfflineWebamp
+  setCurrentPlayedTrack,
+  setOfflineWebamp,
+  setOnTrackChangedCallback
 } from "../../actions/webamp";
 import { AppState } from "../../reducers";
 
@@ -23,6 +25,9 @@ export default () => {
       if (webampObject) {
         dispatch(removeWebamp());
         dispatch(setConnectedWebamp());
+        dispatch(
+          setOnTrackChangedCallback(x => dispatch(setCurrentPlayedTrack(x)))
+        );
       }
     } else dispatch(setOfflineWebamp());
 

--- a/js/reducers/index.ts
+++ b/js/reducers/index.ts
@@ -12,7 +12,7 @@ import searchPagination, {
   initialStateSearchPagination,
   SearchPaginationState
 } from "./search-pagination";
-import settings, { initialSettingsState } from "./settings";
+import settings, { initialSettingsState, SettingsState } from "./settings";
 import theme, { ThemeState } from "./theme";
 import user, { initialStateUser, UserState } from "./user";
 import webamp, { initialStateWebamp, WebampState } from "./webamp";

--- a/js/reducers/webamp.ts
+++ b/js/reducers/webamp.ts
@@ -9,14 +9,17 @@ export enum WEBAMP_STATUS {
 export interface WebampState {
   webampObject: Webamp;
   status: WEBAMP_STATUS;
+  currentTrack?: WebampInstance.TrackInfo;
 }
 
 export const initialStateWebamp: WebampState = {
   webampObject: null,
-  status: WEBAMP_STATUS.STOPPED
+  status: WEBAMP_STATUS.STOPPED,
+  currentTrack: null
 };
 
 export const SET_WEBAMP = "SET_WEBAMP";
+export const SET_CURRENT_TRACK = "SET_CURRENT_TRACK";
 export const PLAY = "PLAY";
 
 const webamp = (state: WebampState = initialStateWebamp, action: any) => {
@@ -30,6 +33,11 @@ const webamp = (state: WebampState = initialStateWebamp, action: any) => {
       return {
         ...state,
         status: WEBAMP_STATUS.PLAYING
+      };
+    case SET_CURRENT_TRACK:
+      return {
+        ...state,
+        currentTrack: action.payload.track
       };
     default:
       return state;


### PR DESCRIPTION
# About PR

Hi, as I wrote at twitter, I tried to make connector for web-scrobbler, but some modifications required to do.

Web-scrobbler injects connector into page by URL and listen DOM changes at specific element

Webamp have a tricky marquee to parse, so I decided to make life a bit easier

![Webamp marquee](https://i.imgur.com/snAVBnX.png)

# Features:

- Storing current track at Redux
![store](https://i.imgur.com/xEc9zpt.png)
- Changing title at task bar with currently played track (Artist - Trackname) 
![taskbar](https://i.imgur.com/EAJPbcI.png)
- Hidden div with current track metadata block
![Metadata](https://i.imgur.com/vYiTaZT.png)

# How to check it out

Clone, build and install web-scrobbler plugin
[Web-scrobbler with connector](https://github.com/Keroosha/web-scrobbler/tree/winampify-connector-with-localhost)
[Build instructions](https://github.com/web-scrobbler/web-scrobbler/wiki/Setup-development-environment)

Then just login into last.fm at plugin options and play some music at winampify
(winampify-connector-with-localhost branch already have localhost:8888 as allowed host)